### PR TITLE
Single click copies YouTube URL to the clipboard

### DIFF
--- a/youtubeui.py
+++ b/youtubeui.py
@@ -48,6 +48,7 @@ class Ui_Dialog(object):
         self.listWidget.setObjectName(_fromUtf8("listWidget"))
         self.retranslateUi(Dialog)
         self.pushButton.clicked.connect(self.search)
+	self.listWidget.itemClicked.connect(self.copy)
         self.listWidget.itemDoubleClicked.connect(self.surf)
 
     def search(self):
@@ -61,6 +62,15 @@ class Ui_Dialog(object):
         #print video_ret
         # print len(video_list)
         self.listWidget.addItems(video_ret)
+
+#######################################################################
+    def copy(self):
+        url = parse_url(self.listWidget.currentRow())
+        import subprocess
+        URL = "https://www.youtube.com/watch?v=" + url
+	clipboard = QtGui.QApplication.clipboard()
+	clipboard.setText(URL)        
+
 
 #######################################################################
     def surf(self):


### PR DESCRIPTION
I added a small change; single click copies the selected URL to clipboard.

I can use it nicely together with [kodi-cli](https://github.com/elpraga/kodi-cli) to send it directly to Kodi when I need it. 

I wanted to map it to `Ctrl+click`, but I have never seen pyqt4, so I didn't figure out how to do it.

